### PR TITLE
Update eesti-kirjandusmuuseumi-arhiivide-avaandmed.md

### DIFF
--- a/_datasets/eesti-kirjandusmuuseumi-arhiivide-avaandmed.md
+++ b/_datasets/eesti-kirjandusmuuseumi-arhiivide-avaandmed.md
@@ -17,6 +17,7 @@ category_en:
 resources:
   - name: Eesti Kirjandusmuuseumi arhiivide avaandmed
     url: 'http://kivike.kirmus.ee/index.php?dok_id=38&module=2&op='
+    url: 'https://metashare.ut.ee/repository/search/?q=Eesti+Kirjandusmuuseum'
     format: HTML
     interactive: 'True'
 license: 'https://creativecommons.org/licenses/by-sa/3.0/ee/legalcode'

--- a/eesti-kirjandusmuuseumi-keeleressursid
+++ b/eesti-kirjandusmuuseumi-keeleressursid
@@ -1,0 +1,30 @@
+---
+schema: default
+title: Eesti Kirjandusmuuseumi keeleressursid 
+title_en: Language Resources of Estonian Literary Museum 
+notes: "Eesti Kirjandusmuuseum (EKM) on Eesti Keeleressursside Keskuse (EKRK, https://keeleressursid.ee/et/eesti-keeleressursside-keskus) 
+konsortsiumliige. EKRK failirepositooriumis Metashare.ut.ee on registreeritud ja kättesaadavaks tehtud mitmeid Eesti Kirjandusmuuseumi 
+kogude materjali, nagu näiteks Eesti mõistatused, Kodavere pajatused, anekdoodid, Eesti 1920ndate aastate kirjanduskriitikakorpus. Erinevatel resurrsidel
+on erinevad litsentsid ja kasutuspiirangud."
+notes_en: 'Estonian Literary Museum is the partner of Center of Estonian Language Resources (CELR, https://keeleressursid.ee/en/).
+The partners belonging to the CELR consortium are University of Tartu, Tallinn University of Technology, Institute of the Estonian 
+Language and Estonian Literary Museum.'
+department: ''
+category:
+  - Haridus, kultuur ja sport
+category_en:
+  - Education, Culture and Sport
+resources:
+  - name: Eesti Kirjandusmuuseumi keeleressursid
+    url: 'https://metashare.ut.ee/repository/search/?q=Eesti+Kirjandusmuuseum'
+    format: HTML
+    interactive: 'True'
+license: 'http://www.meta-share.org/knowledgebase/licence'
+update_freq: ''
+date_issued: 2019/06/27
+date_modified: 2019/06/27
+organization: Eesti Kirjandusmuuseum
+maintainer_name: Siiri Pärkson
+maintainer_email: siiri.parkson@kirmus.ee
+maintainer_phone: ''
+---

--- a/eesti-kirjandusmuuseumi-keeleressursid
+++ b/eesti-kirjandusmuuseumi-keeleressursid
@@ -19,7 +19,7 @@ resources:
     url: 'https://metashare.ut.ee/repository/search/?q=Eesti+Kirjandusmuuseum'
     format: HTML
     interactive: 'True'
-license: 'http://www.meta-share.org/knowledgebase/licence'
+license: 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode'
 update_freq: ''
 date_issued: 2019/06/27
 date_modified: 2019/06/27


### PR DESCRIPTION
Lisatud Eesti Keeleressursside Keskuse, mille konsortsiumliige Eesti Kirjandusmuuseum on, repositooriumi Metashare Eesti Kirjandusmuuseumi avalikke korpusi puudutav link. Iga keeleressursi juures on ka litsents.